### PR TITLE
rename package calls and install

### DIFF
--- a/global.R
+++ b/global.R
@@ -16,7 +16,7 @@ library(zoo) # na.trim function
 library(readr) # csv manipulation
 library(mgcv) # gam function (lisser les courbes)
 
-library(telraamStats)
+library(telraamStatsAgisTaTerre)
 
 ########
 # File import

--- a/install-packages-deploy.R
+++ b/install-packages-deploy.R
@@ -1,2 +1,2 @@
 install.packages(c('tidyverse','shiny', 'httr', 'jsonlite', 'lubridate', 'cowplot', 'CPAT', 'synchrony', 'forecast', 'zoo', 'readr', 'mgcv', 'remotes', 'rsconnect'), repos='https://cran.rstudio.com/')
-remotes::install_github('agistaterre/telraamStats')
+remotes::install_github('agistaterre/telraamStatsAgisTaTerre')

--- a/install-packages-update.R
+++ b/install-packages-update.R
@@ -1,2 +1,2 @@
 install.packages(c("lubridate","purrr","jsonlite","readr","httr","dplyr", "remotes"))
-remotes::install_github("agistaterre/telraamStats")
+remotes::install_github("agistaterre/telraamStatsAgisTaTerre")

--- a/params.R
+++ b/params.R
@@ -27,4 +27,4 @@ ending_date <- Sys.Date()
 ########
 
 key <- Sys.getenv("TELRAAM_KEY")
-telraamStats::set_telraam_token(key)
+telraamStatsAgisTaTerre::set_telraam_token(key)

--- a/update-database.R
+++ b/update-database.R
@@ -5,7 +5,7 @@ library(readr)
 library(httr)
 library(dplyr)
 
-library(telraamStats)
+library(telraamStatsAgisTaTerre)
 
 source('params.R')
 


### PR DESCRIPTION
"telraamStats has been moved and renamed: the package that serves as the back-end for the Mov'Around application is now named 'telraamStatsAgisTaTerre' and is located in the repository of the same name. The application must be modified to reflect this change.